### PR TITLE
fix: showform date/time fields cleared on redisplay after failed validation

### DIFF
--- a/planetplum/forms.py
+++ b/planetplum/forms.py
@@ -93,9 +93,24 @@ class ShowForm(forms.ModelForm):
     field_order = ['image', 'date', 'location', 'name', 'price', 'pwyc', 'time', 'ticketlink']
 
     class Meta:
-        model = Show 
+        model = Show
         fields = ['image', 'date', 'location', 'name', 'price', 'pwyc', 'time', 'ticketlink']
         labels = {'ticketlink': 'Ticket Link',}
+        widgets = {
+            # Explicit type="date"/"time" tells Django to always format the
+            # value as the HTML5 spec requires (YYYY-MM-DD / HH:MM),
+            # regardless of locale -- and, just as important, to do it
+            # correctly on every render path: a fresh form, an edit form
+            # bound to an existing Show instance, *and* a redisplay after
+            # failed validation (e.g. a bad image file), where the value
+            # comes back as the raw submitted string rather than a
+            # date/time object. Templates that used the `date`/`time`
+            # filters directly on `section.value` cleared the field on that
+            # last path, because those filters expect a date/time object
+            # and silently produce nothing for a plain string.
+            'date': forms.DateInput(attrs={'type': 'date'}),
+            'time': forms.TimeInput(attrs={'type': 'time'}),
+        }
 
 class VenueForm(forms.ModelForm):
     class Meta:

--- a/planetplum/templates/contribute/add/addshow.html
+++ b/planetplum/templates/contribute/add/addshow.html
@@ -31,10 +31,10 @@ add show
                 {% if section.name == "image" %}
                 {% elif section.name == "date" %}
                     <h2>Date</h2>
-                    <input type="date" name="date" required id="id_date" value="{{ section.value|date:"Y-m-d" }}">
+                    {{ section }}
                 {% elif section.name == "time" %}
                     <h2>Time</h2>
-                    <input type="time" name="time" id="id_time" value="{{ section.value|time:"H:i" }}">
+                    {{ section }}
                 {% elif section.name == "name" %}
                     <br><hr>
                     <p>(optional details)</p><br>

--- a/planetplum/templates/contribute/edit/editshow.html
+++ b/planetplum/templates/contribute/edit/editshow.html
@@ -29,14 +29,10 @@ edit show
                 {% if section.name == "image" %}
                 {% elif section.name == "date" %}
                     <h2>Date</h2>
-                    <input type="date" name="date" required id="id_date" value="{{ section.value|date:"Y-m-d" }}">
+                    {{ section }}
                 {% elif section.name == "time" %}
                     <h2>Time</h2>
-                    {% if section.value %}
-                        <input type="time" name="time" id="id_time" value="{{ section.value|time:"H:i" }}">
-                    {% else %}
-                        <input type="time" name="time" id="id_time">
-                    {% endif %}
+                    {{ section }}
                 {% elif section.name == "name" %}
                     <h2>Show Title</h2>
                     {{ section }}


### PR DESCRIPTION
## What & why

If a user is forced to resubmit `ShowForm` for any reason (e.g. an incompatible image file), the date field went blank instead of holding what they'd entered — and, it turns out, the `time` field had the identical bug, which the issue flagged as a possibility ("Could be deeper than that").

**Root cause:** both templates rendered the field by hand with `{{ section.value|date:"Y-m-d" }}` / `{{ section.value|time:"H:i" }}`. On a fresh GET, `section.value` is `None` (or a `date`/`time` object for `editShow`'s bound instance) and the filter works fine. But on a bound, invalid form — the redisplay-after-failed-validation case — Django's `section.value()` returns the field's *raw submitted string*, and Django's `date`/`time` template filters silently produce an empty string when given a plain string instead of a date/time object. So a value that was already a correctly-formatted `Y-m-d` string got wiped by trying to reformat it as one.

## Changes

- `forms.py`: declare explicit `type="date"` / `type="time"` widgets on `ShowForm.Meta`.
- Both templates: render the fields with `{{ section }}` instead of hand-rolling the `<input>` tag.

Widgets with an HTML5 `date`/`time` type are special-cased by Django to always format the value in the type's required format, correctly, on every render path — unbound, bound-to-an-instance, and bound-invalid. That's what actually fixes this, rather than patching the specific filter call.

## Testing

This repo has no test suite/CI, and the full app needs S3/email env vars I don't have in this sandbox, so I verified directly against `ShowForm` with a standalone script (not included in the diff):

- Confirmed the **old** code actually had the bug: `section.value()` returns `'2026-08-15'`, and `django.template.defaultfilters.date('2026-08-15', "Y-m-d")` returns `''`.
- Confirmed the **new** widget-based rendering keeps both `date` and `time` intact (`value="2026-08-15"`, `value="19:30:00"`) on a bound, invalid form, and still renders correctly on a fresh unbound form.

Closes #54