### PR TITLE
fix: preserve show date field after validation error

### DIFF
--- a/planetplum/templates/contribute/add/addshow.html
+++ b/planetplum/templates/contribute/add/addshow.html
@@ -31,7 +31,7 @@ add show
                 {% if section.name == "image" %}
                 {% elif section.name == "date" %}
                     <h2>Date</h2>
-                    <input type="date" name="date" required id="id_date" value="{{ section.value|date:"Y-m-d" }}">
+                   {{ section }}
                 {% elif section.name == "time" %}
                     <h2>Time</h2>
                     <input type="time" name="time" id="id_time" value="{{ section.value|time:"H:i" }}">

--- a/planetplum/templates/contribute/edit/editshow.html
+++ b/planetplum/templates/contribute/edit/editshow.html
@@ -29,7 +29,7 @@ edit show
                 {% if section.name == "image" %}
                 {% elif section.name == "date" %}
                     <h2>Date</h2>
-                    <input type="date" name="date" required id="id_date" value="{{ section.value|date:"Y-m-d" }}">
+            {{ section }}
                 {% elif section.name == "time" %}
                     <h2>Time</h2>
                     {% if section.value %}


### PR DESCRIPTION
Fixed the show form date field prefill issue.

Changes:
- Updated date field rendering to use Django bound form value.
- Preserved selected date after validation errors/resubmission.